### PR TITLE
Add Ultimate Personal Assistant service with Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Django-based web application that integrates with n8n to provide user-specific
 - **Workflow Provisioning**: Automatic duplication of n8n templates with user-specific credentials
 - **Service Toggling**: Easy switching between active services
 - **n8n Integration**: Full REST API integration with n8n workflow automation platform
+- **Ultimate Personal Assistant**: AI assistant that connects to Gmail and Google Calendar via Google OAuth2
 
 ## Architecture
 
@@ -152,7 +153,7 @@ Uses `X-N8N-API-KEY` header for n8n API authentication.
 
 ### OAuth2 Flow
 
-For OAuth2 services (like Google Sheets):
+For OAuth2 services (like Gmail or Google Calendar):
 1. User provides OAuth credentials through Django form
 2. Django creates n8n credential
 3. Workflow is provisioned with credential reference

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.db.utils import OperationalError, ProgrammingError
 
 
 class CoreConfig(AppConfig):
@@ -6,5 +7,38 @@ class CoreConfig(AppConfig):
     name = 'core'
 
     def ready(self):
+        """Register signals and ensure default services exist."""
         # Register signals
         from . import signals  # noqa
+
+        # Ensure the Ultimate Personal Assistant service is seeded for existing databases
+        try:
+            from .models import Service
+
+            Service.objects.get_or_create(
+                slug="ultimate-personal-assistant",
+                defaults={
+                    "name": "Ultimate Personal Assistant",
+                    "description": "AI assistant that reads your Gmail and manages Google Calendar events.",
+                    "icon": "fas fa-user-astronaut",
+                    "template_workflow_id": 2,
+                    "credential_type": "googleOAuth2",
+                    "credential_ui_schema": {
+                        "phone_number": {
+                            "type": "text",
+                            "label": "Phone Number",
+                            "placeholder": "+1 555 123 4567",
+                            "required": True,
+                            "help_text": "Used to identify your account for assistant messages",
+                        }
+                    },
+                    "credential_node_types": [
+                        "n8n-nodes-base.gmail",
+                        "n8n-nodes-base.googleCalendar",
+                    ],
+                    "is_active": True,
+                },
+            )
+        except (OperationalError, ProgrammingError):
+            # Database not ready (migrations haven't run yet)
+            pass

--- a/core/fixtures/services.json
+++ b/core/fixtures/services.json
@@ -30,5 +30,33 @@
       "created_at": "2024-01-01T00:00:00Z",
       "updated_at": "2024-01-01T00:00:00Z"
     }
+  },
+  {
+    "model": "core.service",
+    "pk": 2,
+    "fields": {
+      "slug": "ultimate-personal-assistant",
+      "name": "Ultimate Personal Assistant",
+      "description": "AI assistant that reads your Gmail and manages Google Calendar events.",
+      "icon": "fas fa-user-astronaut",
+      "template_workflow_id": 2,
+      "credential_type": "googleOAuth2",
+      "credential_ui_schema": {
+        "phone_number": {
+          "type": "text",
+          "label": "Phone Number",
+          "placeholder": "+1 555 123 4567",
+          "required": true,
+          "help_text": "Used to identify your account for assistant messages"
+        }
+      },
+      "credential_node_types": [
+        "n8n-nodes-base.gmail",
+        "n8n-nodes-base.googleCalendar"
+      ],
+      "is_active": true,
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-01-01T00:00:00Z"
+    }
   }
 ]

--- a/core/migrations/0007_seed_ultimate_assistant.py
+++ b/core/migrations/0007_seed_ultimate_assistant.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+def seed_services(apps, schema_editor):
+    Service = apps.get_model('core', 'Service')
+    defaults = {
+        'name': 'Ultimate Personal Assistant',
+        'description': 'AI assistant that reads your Gmail and manages Google Calendar events.',
+        'icon': 'fas fa-user-astronaut',
+        'template_workflow_id': 2,
+        'credential_type': 'googleOAuth2',
+        'credential_ui_schema': {
+            'phone_number': {
+                'type': 'text',
+                'label': 'Phone Number',
+                'placeholder': '+1 555 123 4567',
+                'required': True,
+                'help_text': 'Used to identify your account for assistant messages',
+            },
+        },
+        'credential_node_types': [
+            'n8n-nodes-base.gmail',
+            'n8n-nodes-base.googleCalendar',
+        ],
+        'is_active': True,
+    }
+    Service.objects.update_or_create(slug='ultimate-personal-assistant', defaults=defaults)
+
+
+def unseed_services(apps, schema_editor):
+    Service = apps.get_model('core', 'Service')
+    Service.objects.filter(slug='ultimate-personal-assistant').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0006_alter_userprofile_phone_number'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_services, unseed_services),
+    ]

--- a/core/templates/core/service_detail.html
+++ b/core/templates/core/service_detail.html
@@ -395,7 +395,7 @@
             </div>
             <h3 class="oauth-notice-title">Google OAuth2 Integration</h3>
             <p class="oauth-notice-text">
-                This service requires Google OAuth2 authentication. You'll be redirected to Google to authorize access to your Google Sheets.
+                This service requires Google OAuth2 authentication. You'll be redirected to Google to authorize access to your Gmail and Google Calendar.
                 Make sure your n8n instance is properly configured with Google OAuth2 credentials.
             </p>
         </div>
@@ -410,7 +410,7 @@
                 <p class="form-subtitle">
                     {% if service.credential_type == 'googleOAuth2' %}
                         Connect your Google account to get started
-                    {% elif service.slug == 'budget-tracker' and user_has_phone %}
+                    {% elif needs_phone and user_has_phone %}
                         Your phone number from signup will be used automatically
                     {% else %}
                         Provide the required information to unlock this service
@@ -419,7 +419,7 @@
             </div>
 
             <!-- Phone number notice for budget tracker users who already have one -->
-            {% if service.slug == 'budget-tracker' and user_has_phone %}
+            {% if needs_phone and user_has_phone %}
             <div class="phone-notice">
                 <div class="phone-notice-icon">
                     <i class="fas fa-mobile-alt"></i>


### PR DESCRIPTION
## Summary
- add Ultimate Personal Assistant service fixture and migration
- handle phone number and OAuth provisioning for new service
- document Google OAuth requirements for assistant service
- ensure Ultimate Personal Assistant service is auto-seeded on startup

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b9b3871483339568c6bdbb6fffc8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced “Ultimate Personal Assistant” service integrating Gmail and Google Calendar via Google OAuth2.
  * Added phone number support: collected at signup, validated for uniqueness, and reused across services; prompts only when missing.
  * Streamlined credential flow so phone handling is separate from OAuth.

* Documentation
  * Updated README with the new feature entry and revised OAuth2 example to reference Gmail/Google Calendar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->