### PR TITLE
Use N8nClient helper for OAuth authorization

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -9,7 +9,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django import forms
 import json
 import os
-from urllib.parse import quote
 
 from .models import Service, UserWorkflow, BudgetService, Transaction, UserProfile
 from django.utils import timezone
@@ -604,8 +603,7 @@ def handle_oauth_flow(request, service):
         )
 
         # Redirect user to n8n authorize URL for Gmail (which will prompt for both scopes)
-        # Use the correct OAuth auth endpoint
-        authorize_url = f"{client.base}{client.api_prefix}/oauth2-credential/auth?id={primary_cred_id}&redirectAfterAuth={quote(return_uri, safe='')}"
+        authorize_url = client.build_oauth_authorize_url(primary_cred_id, return_uri)
         return redirect(authorize_url)
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Use `N8nClient.build_oauth_authorize_url` for constructing the OAuth redirect URL in `handle_oauth_flow`
- Remove unused `quote` import

## Testing
- `python -m pytest`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c221a59dac833386b0dc3d57c89f35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Gmail OAuth sign-in by centralizing authorization URL generation in the client layer, reducing duplication and improving maintainability. Redirect behavior and error handling remain unchanged, with no user-facing impact expected.
  * Consolidation lowers the risk of configuration inconsistencies across environments and makes future adjustments to the OAuth flow easier without altering existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->