### PR TITLE
Support n8n UI prefix for OAuth authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ POSTGRES_PORT=5432
 # n8n Configuration
 N8N_API_BASE_URL=https://your-n8n-instance.com
 N8N_API_KEY=your-n8n-api-key
+N8N_API_PREFIX=/api/v1  # optional, defaults to /api/v1
+N8N_UI_PREFIX=/rest     # optional, defaults to /rest
 ```
 
 4. **Run migrations:**


### PR DESCRIPTION
## Summary
- Add `N8N_UI_PREFIX` configuration for UI-specific n8n routes
- Use UI prefix and `credentialId` when building OAuth authorization URL
- Document `N8N_UI_PREFIX` and `N8N_API_PREFIX` environment variables

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c264969884833382dd61ec13808e0e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional environment variables to customize n8n paths: N8N_API_PREFIX and N8N_UI_PREFIX.

- Bug Fixes
  - Improved OAuth connection flow by resolving provider URLs via the server for better compatibility.
  - Added clearer error messages when OAuth initiation fails.

- Documentation
  - Updated README with configuration details and defaults for N8N_API_PREFIX (/api/v1) and N8N_UI_PREFIX (/rest).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->